### PR TITLE
Add support for VSCodium

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,16 @@ export function allEditors() {
 			],
 		},
 		{
+			id: 'vscodium',
+			name: 'VSCodium',
+			binary: 'codium',
+			isTerminalEditor: false,
+			paths: [
+				'/Applications/VSCodium.app/Contents/Resources/app/bin/codium',
+			],
+			keywords: [],
+		},
+		{
 			id: 'webstorm',
 			name: 'WebStorm',
 			binary: 'webstorm',

--- a/test.js
+++ b/test.js
@@ -36,6 +36,12 @@ test('getEditor() - Visual Studio Code', t => {
 	t.is(getEditor('Visual Studio Code').id, 'vscode');
 });
 
+test('getEditor() - VSCodium', t => {
+	t.is(getEditor('vscodium').id, 'vscodium');
+	t.is(getEditor('codium').id, 'vscodium');
+	t.is(getEditor('VSCodium').id, 'vscodium');
+});
+
 test('getEditor() - WebStorm', t => {
 	t.is(getEditor('webstorm').id, 'webstorm');
 	t.is(getEditor('wstorm').id, 'webstorm');


### PR DESCRIPTION
My personal preference is [VSCodium](https://vscodium.com/), the "Free/Libre Open Source Software Binaries of VS Code" as stated on the home page.
I just added it to the list of available editors.
As I am not using a Mac I could not test the "path", but I think it is the correct one.